### PR TITLE
FEAT: add rate limiter to public API's

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.2.6",
     "eslint": "8.32.0",
     "eslint-config-next": "13.1.6",
+    "lru-cache": "^7.14.1",
     "next": "13.1.6",
     "next-pwa": "^5.6.0",
     "react": "18.2.0",

--- a/src/libs/utils/rate-limiter.ts
+++ b/src/libs/utils/rate-limiter.ts
@@ -1,0 +1,35 @@
+import LRU from "lru-cache";
+import type { NextApiResponse } from "next";
+
+type Options = {
+  uniqueTokenPerInterval?: number;
+  interval?: number;
+};
+
+export default function rateLimit(options?: Options) {
+  const tokenCache = new LRU({
+    max: options?.uniqueTokenPerInterval || 500,
+    ttl: options?.interval || 60000,
+  });
+
+  return {
+    check: (res: NextApiResponse, limit: number, token: string) =>
+      new Promise<void>((resolve, reject) => {
+        const tokenCount = (tokenCache.get(token) as number[]) || [0];
+        if (tokenCount[0] === 0) {
+          tokenCache.set(token, tokenCount);
+        }
+        tokenCount[0] += 1;
+
+        const currentUsage = tokenCount[0];
+        const isRateLimited = currentUsage >= limit;
+        res.setHeader("X-RateLimit-Limit", limit);
+        res.setHeader(
+          "X-RateLimit-Remaining",
+          isRateLimited ? 0 : limit - currentUsage
+        );
+
+        return isRateLimited ? reject() : resolve();
+      }),
+  };
+}

--- a/src/pages/api/short-links/[id].ts
+++ b/src/pages/api/short-links/[id].ts
@@ -5,11 +5,9 @@ export default async function handle(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const slugID = req.query.id as string;
-
   switch (req.method) {
     case "GET":
-      return getShortLinkByID(slugID, res);
+      return getShortLinkByID(req, res);
 
     default:
       return res.status(404).json({
@@ -19,7 +17,8 @@ export default async function handle(
   }
 }
 
-async function getShortLinkByID(slug: string, res: NextApiResponse) {
+async function getShortLinkByID(req: NextApiRequest, res: NextApiResponse) {
+  const slug = req.query.id as string;
   const result = await prismaClient.shortLinks.findUnique({
     where: {
       slug,
@@ -32,7 +31,6 @@ async function getShortLinkByID(slug: string, res: NextApiResponse) {
   if (result) {
     return res.json(result);
   }
-
   return res
     .status(404)
     .send({ error: `Couldn't find '${slug}', which was requested` });

--- a/src/pages/api/short-links/index.ts
+++ b/src/pages/api/short-links/index.ts
@@ -1,36 +1,54 @@
 import prismaClient from "@/libs/prisma";
 import { slugsUUID } from "@/libs/utils/common-utils";
+import rateLimit from "@/libs/utils/rate-limiter";
+import { urlValidation } from "@/libs/validations";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { urlValidation } from "../../../libs/validations";
+
+const limiter = rateLimit({
+  interval: 60 * 1000, // 60 seconds
+  uniqueTokenPerInterval: 500, // Max 500 users per second
+});
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (req.method === "POST") {
-    const { url } = req.body;
-    const slug = slugsUUID();
-    try {
-      urlValidation.parse(url);
-      const result = await prismaClient.shortLinks.create({
-        data: {
-          slug,
-          url,
-        },
-        select: {
-          slug: true,
-        },
-      });
-      return res.status(201).send(result);
-    } catch (error) {
-      return res
-        .status(400)
-        .send({ error: `Bad request. Please provide a valid URL` });
-    }
-  }
+  try {
+    await limiter.check(res, 10, "CACHE_TOKEN"); // API RATE LIMITER
+    switch (req.method) {
+      case "POST":
+        return handlePostMethod(req, res);
 
-  return res.status(404).json({
-    message: `The HTTP ${req.method} method is not supported at this route.`,
-    status: 404,
-  });
+      default:
+        return res.status(404).json({
+          message: `The HTTP ${req.method} method is not supported at this route.`,
+          status: 404,
+        });
+    }
+  } catch (error) {
+    res.status(429).json({ error: "Rate limit exceeded" });
+  }
+}
+
+async function handlePostMethod(req: NextApiRequest, res: NextApiResponse) {
+  const { url } = req.body;
+  const slug = slugsUUID();
+  try {
+    urlValidation.parse(url);
+    const result = await prismaClient.shortLinks.create({
+      data: {
+        slug,
+        url,
+      },
+      select: {
+        slug: true,
+      },
+    });
+    return res.status(201).send(result);
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(400)
+      .send({ error: `Bad request. Please provide a valid URL` });
+  }
 }


### PR DESCRIPTION


- Limit < 10 Req per min.
- Based on an official example from [Next.js](https://github.com/vercel/next.js/tree/canary/examples/api-routes-rate-limit)
